### PR TITLE
Add missing use statements

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@ use 5.010_001;
 use strict;
 use warnings FATAL => 'all';
 
+use lib '.';
 use inc::Module::Install 0.91;
 
 homepage 'http://search.cpan.org/perldoc?DBIx%3A%3AClass%3A%3ASims';

--- a/t/classes/column.t
+++ b/t/classes/column.t
@@ -56,6 +56,8 @@ BEGIN {
 use common qw(Schema);
 =cut
 
+use DBIx::Class::Sims;
+
 my $source = bless {
   runner => { predictable_values => 0 },
 }, 'DBIx::Class::Sims::Source';

--- a/t/classes/item.t
+++ b/t/classes/item.t
@@ -4,6 +4,8 @@ use strictures 2;
 use Test2::V0 qw( done_testing ok ); #subtest match is bag item );
 use Test::Trap; # Needed for trap()
 
+use DBIx::Class::Sims;
+
 my $item = DBIx::Class::Sims::Item->new(
   runner => undef,
   source => undef,

--- a/t/normalize_input.t
+++ b/t/normalize_input.t
@@ -4,6 +4,7 @@ use strictures 2;
 use Test2::V0 qw( done_testing subtest is );
 
 use File::Temp qw( tempfile );
+use DBIx::Class::Sims;
 
 my $sub = \&DBIx::Class::Sims::normalize_input;
 

--- a/t/types_list.t
+++ b/t/types_list.t
@@ -2,6 +2,7 @@
 use strictures 2;
 
 use Test2::V0 qw( done_testing bag item is );
+use DBIx::Class::Sims;
 
 is(
   [ DBIx::Class::Sims->sim_types ],


### PR DESCRIPTION
Newer versions of Perl don't include `.` in `@INC`, and so a modification to `Makefile.PL` was necessary.

Also adds a few missing `use` statements to some of the tests, which were failing due to the modules being tested not having been loaded yet.