### PR TITLE
Do not force global `Hash::Merge` behaviour, use a localized behaviour.

### DIFF
--- a/lib/DBIx/Class/Sims.pm
+++ b/lib/DBIx/Class/Sims.pm
@@ -37,7 +37,7 @@ use DDP;
 use Data::Walk qw( walk );
 use DateTime;
 use DBIx::Class::TopoSort ();
-use Hash::Merge qw( merge );
+use Hash::Merge;
 use List::Util qw( first );
 use List::MoreUtils qw( natatime );
 use Scalar::Util qw( blessed );
@@ -105,17 +105,16 @@ use DBIx::Class::Sims::Types;
 use DBIx::Class::Sims::Runner;
 use DBIx::Class::Sims::Util qw( normalize_aoh reftype );
 
-Hash::Merge::set_behavior('RIGHT_PRECEDENT');
-
 sub add_sims {
   my $class = shift;
   my ($schema, $source, @remainder) = @_;
 
   my $rsrc = $schema->source($source);
   my $it = natatime(2, @remainder);
+  my $merger = Hash::Merge->new('RIGHT_PRECEDENT');
   while (my ($column, $sim_info) = $it->()) {
     my $col_info = $schema->source($source)->column_info($column) // next;
-    $col_info->{sim} = merge(
+    $col_info->{sim} = $merger->merge(
       $col_info->{sim} // {},
       $sim_info // {},
     );
@@ -265,6 +264,7 @@ sub massage_input {
   my ($schema, $struct) = @_;
 
   my $dtp = $schema->storage->datetime_parser;
+  my $merger = Hash::Merge->new('RIGHT_PRECEDENT');
   walk({
     preprocess => sub {
       # Don't descend into the weeds. Only do the things we care about.
@@ -279,7 +279,7 @@ sub massage_input {
 
         # Expand the dot-naming convention.
         while ( $k =~ /([^.]*)\.(.*)/ ) {
-          $t->{$1} = merge(
+          $t->{$1} = $merger->merge(
             ($t->{$1} // {}),
             { $2 => delete($t->{$k}) },
           );

--- a/lib/DBIx/Class/Sims/Item.pm
+++ b/lib/DBIx/Class/Sims/Item.pm
@@ -11,7 +11,7 @@ use strictures 2;
 use DDP;
 
 use List::PowerSet qw(powerset);
-use Hash::Merge qw( merge );
+use Hash::Merge;
 use Scalar::Util qw( blessed );
 
 use DBIx::Class::Sims::Util qw(
@@ -644,7 +644,8 @@ sub populate_column {
   };
 
   if ( $merge_spec->( $spec ) ) {
-    $spec = merge( $c->sim_spec // {}, $spec );
+    my $merger = Hash::Merge->new('RIGHT_PRECEDENT');
+    $spec = $merger->merge( $c->sim_spec // {}, $spec );
   }
   else {
     $spec //= $c->sim_spec;


### PR DESCRIPTION
Forcing the global precedence for `Hash::Merge` requires that anyone
using `DBIx::Class::Sims` accept `RIGHT_PRECEDENT` for all of their bare
calls to `merge()`.

Similarly... let's not rely on or expect the global precedence behaviour
for `Hash::Merge` to have the default precedence.  Instead, create our
own instance via `Hash::Merge->new(...)`, and set the precedence we
want.

That way, we know that

(a) we've always got the precedence we want (`RIGHT_PRECEDENT`), and
(b) if someone elses changes the global behaviour, it won't affect us.