### PR TITLE
Oops, forgot to remove this file from our `MANIFEST`.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -10,7 +10,6 @@ inc/Module/Install/Makefile.pm
 inc/Module/Install/Metadata.pm
 inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
-lib/DateTime/Event/Random.pm
 lib/DBIx/Class/Sims/Column.pm
 lib/DBIx/Class/Sims/Item.pm
 lib/DBIx/Class/Sims/Random.pm


### PR DESCRIPTION
We previously removed our local copy of `DateTime::Event::Random` from
the distribution, but accidentally forgot to remove it from the
`MANIFEST` file as well.