### PR TITLE
We require `strictures 2`, so be clear/explicit about that.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ resources 'bugtracker'  => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=DBIx-Class-
 perl_version '5.010_001';
 all_from 'lib/DBIx/Class/Sims.pm';
 
-requires 'strictures';
+requires 'strictures' => '2';
 requires 'Data::Compare';
 requires 'Data::Printer' => '0.36'; # np() isn't exported before 0.36+
 requires 'Data::Walk';

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'strictures';
+requires 'strictures' => '2';
 requires 'Data::Compare';
 requires 'Data::Printer' => '0.36';
 requires 'Data::Walk';


### PR DESCRIPTION
With thanks to CPANTesters, which failed a test run due to an older
version of `strictures` being installed.